### PR TITLE
Fix Issue #3 / RT #84144: HTML::Entities::decode_entities() needs to call SV_CHECK_THINKFIRST() before checking READONLY flag

### DIFF
--- a/Parser.xs
+++ b/Parser.xs
@@ -616,8 +616,13 @@ decode_entities(...)
 	for (i = 0; i < items; i++) {
 	    if (GIMME_V != G_VOID)
 	        ST(i) = sv_2mortal(newSVsv(ST(i)));
-	    else if (SvREADONLY(ST(i)))
-		croak("Can't inline decode readonly string");
+	    else {
+#ifdef SV_CHECK_THINKFIRST
+                SV_CHECK_THINKFIRST(ST(i));
+#endif
+                if (SvREADONLY(ST(i)))
+		    croak("Can't inline decode readonly string in decode_entities()");
+            }
 	    decode_entities(aTHX_ ST(i), entity2char, 0);
 	}
 	SP += items;
@@ -641,8 +646,11 @@ _decode_entities(string, entities, ...)
         else {
             entities_hv = 0;
         }
+#ifdef SV_CHECK_THINKFIRST
+        SV_CHECK_THINKFIRST(string);
+#endif
 	if (SvREADONLY(string))
-	    croak("Can't inline decode readonly string");
+	    croak("Can't inline decode readonly string in _decode_entities()");
 	decode_entities(aTHX_ string, entities_hv, expand_prefix);
 
 bool

--- a/t/entities.t
+++ b/t/entities.t
@@ -1,6 +1,6 @@
 use HTML::Entities qw(decode_entities encode_entities encode_entities_numeric);
 
-use Test::More tests => 18;
+use Test::More tests => 20;
 
 $a = "V&aring;re norske tegn b&oslash;r &#230res";
 
@@ -53,6 +53,17 @@ $a = $plain;
 encode_entities($a);
 is($a, $ent);
 
+{   #RT #84144 - https://rt.cpan.org/Public/Bug/Display.html?id=84144
+
+    my %hash= (
+        "V&aring;re norske tegn b&oslash;r &#230res" => "Våre norske tegn bør æres"
+    );
+
+    my ($got, $eval_ok);
+    $eval_ok= eval { $got= decode_entities((keys %hash)[0]); 1 };
+    is( $eval_ok, 1, "decode_entitites() when processing a key as input");
+    is( $got, (values %hash)[0], "decode_entities() decodes a key properly");
+}
 
 # From: Bill Simpson-Young <bill.simpson-young@cmis.csiro.au>
 # Subject: HTML entities problem with 5.11

--- a/t/entities2.t
+++ b/t/entities2.t
@@ -8,7 +8,7 @@ use HTML::Entities qw(_decode_entities);
 eval {
     _decode_entities("&lt;", undef);
 };
-like($@, qr/^Can't inline decode readonly string/);
+like($@, qr/^(?:Can't inline decode readonly string|Modification of a read-only value attempted)/);
 
 eval {
     my $a = "";


### PR DESCRIPTION
Later versions of Perl have added or changed meanings of various flags. In
particular keys in 5.12 and 5.14 have READONLY+FAKE flags set, which is supposed
to mean "PV is readonly but SV is not", and is supposed to be handled by calling
sv_force_normal_flags() on the SV before operating on it. Bleadperl
changes this to an "IsCOW" flag.

In order to future proof against these kinds of changes it is important
to call SV_CHECK_THINKFIRST() before inspecting the SV. This ensures
that sv_force_normal_flags() is called if needed.

The end result is that HTML::Entities::decode_entities() can handle
arguments obtained from keys() without choking. A minor inconvenience is
that this changes the error message from

  decode_entities("string literal")

from

  Can't inline decode readonly string

to

  Modification of a read-only value attempted

which seems an acceptable cost to pay. I do not know of any backwards
compatible way of checking the flags to both respect the SvTHINKFIRST
macros AND make it possible trap a "true" readonly value. I think
that will require future changes to Perl itself.

This patch includes some new tests to ensure keys() are ok in
decode_entities().
