### PR TITLE
Silence clang warning

### DIFF
--- a/hparser.c
+++ b/hparser.c
@@ -735,7 +735,7 @@ argspec_compile(SV* src, PSTATE* p_state)
 		}
 	    }
 	    else {
-		croak("Unrecognized identifier %.*s in argspec", s - name, name);
+		croak("Unrecognized identifier %.*s in argspec", (int) (s - name), name);
 	    }
 	}
 	else if (*s == '"' || *s == '\'') {


### PR DESCRIPTION
Silence an annoying clang warning.

```
./hparser.c:738:36: warning: field precision should have type 'int', but argument has type 'long' [-Wformat]
                croak("Unrecognized identifier %.*s in argspec", s - name, name);
                                               ~~^~              ~~~~~~~~
```