### PR TITLE
const+static-ing

### DIFF
--- a/Parser.xs
+++ b/Parser.xs
@@ -312,7 +312,7 @@ magic_dup_pstate(pTHX_ MAGIC *mg, CLONE_PARAMS *params)
 
 #endif
 
-MGVTBL vtbl_pstate =
+const MGVTBL vtbl_pstate =
 {
     0,
     0,
@@ -362,7 +362,7 @@ _alloc_pstate(self)
 #endif
 	mg = mg_find(sv, '~');
         assert(mg);
-        mg->mg_virtual = &vtbl_pstate;
+        mg->mg_virtual = (MGVTBL*)&vtbl_pstate;
 #if defined(USE_ITHREADS) && PATCHLEVEL >= 8
         mg->mg_flags |= MGf_DUP;
 #endif

--- a/hparser.c
+++ b/hparser.c
@@ -14,7 +14,7 @@
 #include "tokenpos.h"  /* dTOKEN; PUSH_TOKEN() */
 
 
-static
+const static
 struct literal_tag {
     int len;
     char* str;
@@ -59,7 +59,7 @@ enum argcode {
     ARG_FLAG_FLAT_ARRAY
 };
 
-char *argname[] = {
+static const char * const argname[] = {
     /* Must be in the same order as enum argcode */
     "self",     /* ARG_SELF */
     "tokens",   /* ARG_TOKENS */   
@@ -701,7 +701,7 @@ argspec_compile(SV* src, PSTATE* p_state)
 	if (isHNAME_FIRST(*s) || *s == '@') {
 	    char *name = s;
 	    int a = ARG_SELF;
-	    char **arg_name;
+	    const char * const *arg_name;
 
 	    s++;
 	    while (isHNAME_CHAR(*s))


### PR DESCRIPTION
static data symbols argname and vtbl_pstate to remove ELF plt/got
indirection (these aren't exported on Win32, so they shouldn't be on linux)

Add const to argname, literal_mode_elem and vtbl_pstate so they are stored
in RO memory that is shared between processes by the OS.