### PR TITLE
Parse internal DTDs in doctype declaration

### DIFF
--- a/Parser.pm
+++ b/Parser.pm
@@ -810,8 +810,9 @@ Tokens causes a reference to an array of token strings to be passed.
 The strings are exactly as they were found in the original text,
 no decoding or case changes are applied.
 
-For C<declaration> events, the array contains each word, comment, and
-delimited string starting with the declaration type.
+For C<declaration> events, the array contains each word, comment, 
+internal dtd (including square brackets) and delimited string,
+starting with the declaration type.
 
 For C<comment> events, this contains each sub-comment.  If
 $p->strict_comments is disabled, there will be only one sub-comment.
@@ -884,8 +885,6 @@ Example:
 
   <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
       "http://www.w3.org/TR/html4/strict.dtd">
-
-DTDs inside <!DOCTYPE ...> will confuse HTML::Parser.
 
 =item C<default>
 

--- a/hparser.c
+++ b/hparser.c
@@ -957,6 +957,88 @@ parse_comment(PSTATE* p_state, char *beg, char *end, U32 utf8, SV* self)
     return 0;
 }
 
+static char*
+skip_to_end_comment(PSTATE* p_state, char *beg, char *end)
+{
+    char *s = beg;
+
+    ++s;
+    if (s == end || *s != '!')
+	return beg;
+    ++s;
+    if (s == end || *s != '-')
+	return beg;
+    ++s;
+    if (s == end || *s != '-')
+	return beg;
+
+    if (p_state->strict_comment) {
+	char *start_com = s;  /* also used to signal inside/outside */
+
+	while (1) {
+	    /* try to locate "--" */
+	FIND_DASH_DASH:
+	    while (s < end && *s != '-' && *s != '>')
+		s++;
+
+	    if (s == end)
+		return beg;
+
+	    if (*s == '>') {
+		if (! start_com)
+		    return s;
+		s++;
+		goto FIND_DASH_DASH;
+	    }
+
+	    s++;
+	    if (s == end)
+		return beg;
+
+	    if (*s == '-') {
+		/* two dashes in a row seen */
+		s++;
+		if (start_com)
+		    start_com = 0;
+		else
+		    start_com = s;
+	    }
+	}
+    }
+    else if (p_state->no_dash_dash_comment_end) {
+        /* a lone '>' signals end-of-comment */
+	while (s < end && *s != '>')
+	    s++;
+	if (s == end)
+	    return beg;
+	return s;
+    }
+    else { /* non-strict comment */
+	/* try to locate /--\s*>/ which signals end-of-comment */
+    LOCATE_END:
+	while (s < end && *s != '-')
+	    s++;
+	if (s < end) {
+	    s++;
+	    if (*s == '-') {
+		s++;
+		while (isHSPACE(*s))
+		    s++;
+		if (*s == '>') {
+		    return s;
+		}
+	    }
+	    if (s < end)
+		goto LOCATE_END;
+	}
+
+	if (s == end)
+	    return beg;
+    }
+
+    return 0;
+}
+
 
 #ifdef MARKED_SECTION
 
@@ -1187,7 +1269,7 @@ parse_decl(PSTATE* p_state, char *beg, char *end, U32 utf8, SV* self)
 	    else if (*s == '[') {
 		/* internal DTD section between square brackets */
 		char *intdtd_beg = s;
-		while (s < end && *s != ']') {	/* get the internal dtd - beware of nested comments and strings maybe containing a ] char */
+		while (s < end && *s != ']') {	/* get the internal dtd - beware of nested comments and strings maybe containing a ] and > chars */
 		    if (*s == '"' || *s == '\'' || (*s == '`' && p_state->backquote)) {	/* skip over a quoted string */
 			char *str_beg = s;
 			s++;
@@ -1195,24 +1277,8 @@ parse_decl(PSTATE* p_state, char *beg, char *end, U32 utf8, SV* self)
 			    s++;
 			if (s == end)
 			    goto PREMATURE;
-		    } else if (*s == '-') {	/* and skip over the commment */
-			s++;
-			if (s == end)
-			    goto PREMATURE;
-			if (*s != '-')
-			    goto FAIL;
-			s++;
-			while (1) {
-			    while (s < end && *s != '-')
-				s++;
-			    if (s == end)
-				goto PREMATURE;
-			    s++;
-			    if (s == end)
-				goto PREMATURE;
-			    if (*s == '-')
-				break;
-			}
+		    } else if (*s == '<') {	/* and skip over the commment */
+			s = skip_to_end_comment(p_state, s, end);
 		    }
 		    s++;
 		    if (s == end)

--- a/hparser.c
+++ b/hparser.c
@@ -1184,6 +1184,45 @@ parse_decl(PSTATE* p_state, char *beg, char *end, U32 utf8, SV* self)
 		s++;
 		PUSH_TOKEN(str_beg, s);
 	    }
+	    else if (*s == '[') {
+		/* internal DTD section between square brackets */
+		char *intdtd_beg = s;
+		while (s < end && *s != ']') {	/* get the internal dtd - beware of nested comments and strings maybe containing a ] char */
+		    if (*s == '"' || *s == '\'' || (*s == '`' && p_state->backquote)) {	/* skip over a quoted string */
+			char *str_beg = s;
+			s++;
+			while (s < end && *s != *str_beg)
+			    s++;
+			if (s == end)
+			    goto PREMATURE;
+		    } else if (*s == '-') {	/* and skip over the commment */
+			s++;
+			if (s == end)
+			    goto PREMATURE;
+			if (*s != '-')
+			    goto FAIL;
+			s++;
+			while (1) {
+			    while (s < end && *s != '-')
+				s++;
+			    if (s == end)
+				goto PREMATURE;
+			    s++;
+			    if (s == end)
+				goto PREMATURE;
+			    if (*s == '-')
+				break;
+			}
+		    }
+		    s++;
+		    if (s == end)
+			goto PREMATURE;
+		}
+		s++;
+		if (s == end)
+		    goto PREMATURE;
+		PUSH_TOKEN(intdtd_beg, s);
+	    }
 	    else if (*s == '-') {
 		/* comment */
 		char *com_beg = s;

--- a/t/declaration.t
+++ b/t/declaration.t
@@ -65,6 +65,8 @@ $p->parse(<<EOT)->eof;
 <!DOCTYPE pbi SYSTEM "pbi.dtd" [
 <!-- the [internal] dtd -->
 <!ENTITY brackets "[]">
+<!ENTITY my-ent "<!-- [foo] -->">
+<!-- end of internal dtd -->
 ] >
 <pbi>[Content]</pbi>
 EOT
@@ -76,6 +78,8 @@ is($res, <<EOT);
 <[
 <!-- the [internal] dtd -->
 <!ENTITY brackets "[]">
+<!ENTITY my-ent "<!-- [foo] -->">
+<!-- end of internal dtd -->
 ]>]
 <pbi>[Content]</pbi>
 EOT

--- a/t/declaration.t
+++ b/t/declaration.t
@@ -65,7 +65,8 @@ $p->parse(<<EOT)->eof;
 <!DOCTYPE pbi SYSTEM "pbi.dtd" [
 <!-- the [internal] dtd -->
 <!ENTITY brackets "[]">
-<!ENTITY my-ent "<!-- [foo] -->">
+<!ENTITY my-ent "<!-- [foo] -->" -- [comment] -->
+<!ENTITY dbl--bar " -- [bar] -- ">
 <!-- end of internal dtd -->
 ] >
 <pbi>[Content]</pbi>
@@ -78,7 +79,8 @@ is($res, <<EOT);
 <[
 <!-- the [internal] dtd -->
 <!ENTITY brackets "[]">
-<!ENTITY my-ent "<!-- [foo] -->">
+<!ENTITY my-ent "<!-- [foo] -->" -- [comment] -->
+<!ENTITY dbl--bar " -- [bar] -- ">
 <!-- end of internal dtd -->
 ]>]
 <pbi>[Content]</pbi>

--- a/t/declaration.t
+++ b/t/declaration.t
@@ -1,4 +1,4 @@
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 use HTML::Parser;
 my $res = "";
@@ -58,5 +58,25 @@ is($res, <<EOT);
 <"-//W3C//DTD XHTML 1.0 Strict//EN">
 <"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <[]>]
+EOT
+
+$res = "";
+$p->parse(<<EOT)->eof;
+<!DOCTYPE pbi SYSTEM "pbi.dtd" [
+<!-- the [internal] dtd -->
+<!ENTITY brackets "[]">
+] >
+<pbi>[Content]</pbi>
+EOT
+is($res, <<EOT);
+[<DOCTYPE>
+<pbi>
+<SYSTEM>
+<"pbi.dtd">
+<[
+<!-- the [internal] dtd -->
+<!ENTITY brackets "[]">
+]>]
+<pbi>[Content]</pbi>
 EOT
 


### PR DESCRIPTION
Up to now it was documented that internal DTDs inside the doctype declaration confuse HTML::Parser.
Depending on the content of that internal dtd, the parser would return a text token instead, but sometimes also a declaration token that contained a lot of elements and text appearing after the syntactically correct declaration as well.
The old implementation did allow for the empty internal DTD like:
`<!DOCTYPE abc SYSTEM "abc.dtd" [] >`

This patch allows non-empty internal DTDs inside those square brackets in the doctype declaration, and returns the whole internal DTD as one single token in the list, similar to the token just containing "`[]`" in the old implementation.  E.g. now it correctly parses:

``` xml
<!DOCTYPE abc SYSTEM abc.dtd"[
<!-- even a simple comment here would confuse it -->
<!-- or quoted strings with special chars like ]> -->
<!ENTITY confuse "]>">
] >
<abc>Hello world</abc>
```

Paul
(Ten years after my previous small patch, but still using this very nice perl module, one of the only ones that allows for sane parsing of sgml-like files with errors in it.)
