### PR TITLE
Avoid segfault when freeing parse

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -43,6 +43,7 @@ t/entities.t		Test encoding/decoding of entities
 t/entities2.t		Test _decode_entities()
 t/filter-methods.t	Test ignore_tags, ignore_elements methods.
 t/filter.t		Test HTML::Filter
+t/free.t		Test freeing of active parser
 t/handler-eof.t         Test invocation of $p->eof in handlers
 t/handler.t		Test $p->handler method
 t/headparser-http.t	Test HTML::HeadParser

--- a/Parser.xs
+++ b/Parser.xs
@@ -377,6 +377,7 @@ parse(self, chunk)
     PREINIT:
 	PSTATE* p_state = get_pstate_hv(aTHX_ self);
     PPCODE:
+    (void)sv_2mortal(SvREFCNT_inc(SvRV(self)));
 	if (p_state->parsing)
     	    croak("Parse loop not allowed");
         p_state->parsing = 1;

--- a/t/free.t
+++ b/t/free.t
@@ -1,0 +1,19 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use HTML::Parser;
+
+my $p;
+$p = HTML::Parser->new(
+    start_h => [sub {
+   undef $p;
+    }],
+);
+
+$p->parse(q(<foo>));
+
+pass 'no SEGV';


### PR DESCRIPTION
RT-115034

Protect active parser from being freed

URL: https://rt.cpan.org/Public/Bug/Display.html?id=115034
Author: sprout